### PR TITLE
Use "mod.conf" for 5.0.0+ servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Allows players to colour their chat messages.
 (See the example below.)
 
 ## Installation
-- Unzip the archive, rename the folder to "soccer" (**without the quotes**) and
+- Unzip the archive, rename the folder to chat_c and
 place it in ..minetest/mods/
 
 - GNU/Linux: If you use a system-wide installation place

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Players can prefix their messages with a letter (or series of letters) and it wi
 * r (red)
 * p (pink)
 
-If you type on chat:
+If you type in chat:
 ```
 g Thanks wilkgr
 ```

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ https://wiki.minetest.net/Installing_Mods
 
 ## Dependencies
 - default (included in minetest_game)
-#### Optional dependencies:
+#### Optional dependencies
 - [intllib](https://github.com/minetest-mods/intllib)
 
 ## How to use

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Coloured Chat
-Allows players to colour their chat messages.
+Allows players to colour their chat messages.<br>
 (See the example below.)
 
 ## Installation
-- Unzip the archive, rename the folder to chat_c and
+- Unzip the archive, rename the folder to `chat_c` and
 place it in ..minetest/mods/
 
 - GNU/Linux: If you use a system-wide installation place
@@ -16,9 +16,9 @@ For further information or help, see:
 https://wiki.minetest.net/Installing_Mods
 
 ## Dependencies
-- default (included in minetest_game)
+- `default` (included in minetest_game)
 #### Optional dependencies
-- [intllib](https://github.com/minetest-mods/intllib)
+- [`intllib`](https://github.com/minetest-mods/intllib)
 
 ## How to use
 Players can prefix their messages with a letter (or series of letters) and it will colour their message. 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,26 @@
-# chat_c
-## How to install:
-Extract ZIP file and place in mods/. Alternatively, you can simply "git clone https://github.com/wilkgr76/chat_c" from within the mods directory.
-## How to use:
+# Coloured Chat
+Allows players to colour their chat messages.
+(See the example below.)
+
+## Installation
+- Unzip the archive, rename the folder to "soccer" (**without the quotes**) and
+place it in ..minetest/mods/
+
+- GNU/Linux: If you use a system-wide installation place
+    it in ~/.minetest/mods/.
+
+- If you only want this to be used in a single world, place
+    the folder in ..worldmods/ in your world directory.
+
+For further information or help, see:
+https://wiki.minetest.net/Installing_Mods
+
+## Dependencies
+- default (included in minetest_game)
+#### Optional dependencies:
+- [intllib](https://github.com/minetest-mods/intllib)
+
+## How to use
 Players can prefix their messages with a letter (or series of letters) and it will colour their message. 
 * b (blue)
 * lb (lightblue)
@@ -10,8 +29,7 @@ Players can prefix their messages with a letter (or series of letters) and it wi
 * r (red)
 * p (pink)
 
-## Example
-If you chat
+If you type on chat:
 ```
 g Thanks wilkgr
 ```
@@ -19,4 +37,4 @@ then other players will see:
 ```diff
 + <you> Thanks wilkgr
 ```
-(except for the '+'. That's to make Github highlight it green)
+(except for the '+'. That's to make Github highlight it green.)

--- a/depends.txt
+++ b/depends.txt
@@ -1,1 +1,2 @@
 default
+intllib?

--- a/init.lua
+++ b/init.lua
@@ -1,6 +1,22 @@
+--[[
+Allows players to colour their chat messages.
+Source code: https://github.com/wilkgr76/chat_c
+
+Dependiences: default (included in minetest_game)
+Optional dependiences: intllib
+
+Forum topic: https://forum.minetest.net/viewtopic.php?f=9&t=16814
+License: AGPLv3
+--]]
+
+-- Load support for intllib.
+local MP = minetest.get_modpath(minetest.get_current_modname())
+local S, NS = dofile(MP.."/intllib.lua")
+
 minetest.register_privilege("chat_c", {
-  description = "Can colour their chat",
-  give_to_singleplayer=true
+  description = S("Allows players to colour their chat messages."),
+  give_to_singleplayer = true,
+  give_to_admin = true,  
 })
 
 local helper = {
@@ -13,11 +29,12 @@ local helper = {
 }
 
 minetest.register_on_chat_message(function(name, message)
-  if minetest.get_player_privs(name, {chat_c=true}) then
+  if minetest.get_player_privs(name, {chat_c = true}) then
     for _, row in ipairs(helper) do
       if string.find(message, row[1].." ") == 1 then
               local msg = core.colorize(row[2], string.sub(message,row[3]))
               minetest.chat_send_all("<" .. name .. "> " .. msg)
+            minetest.log("action", ("CHAT: <" .. name .. "> " .. msg))
           return true
       end
     end
@@ -25,11 +42,17 @@ minetest.register_on_chat_message(function(name, message)
 end)
 
 minetest.register_chatcommand("public_warning", {
-   params = "<text>",
-   description = "Send red message",
-   privs = {basic_privs=true},
+   params = S("<text>"),
+   description = S("Sends a public warning to all players."),
+   privs = {basic_privs = true},
    func = function(name, param)
       local msg = core.colorize("red", param);
       minetest.chat_send_all(msg);
+       minetest.log("action", ("PUBLIC WARNING BY " .. name .. ": " .. msg));
    end,
 })
+
+-- Log
+if minetest.settings:get_bool("log_mods") then
+	minetest.log("action", S(("[MOD] Coloured-chat loaded")))
+end

--- a/locale/es.po
+++ b/locale/es.po
@@ -1,0 +1,33 @@
+# Spanish translation for Coloured Chat.
+# Copyright (C) 2017-2019 wilkgr76 and contributors.
+# This file is distributed under under the same license as the Teleport Request package.
+# Panquesito7, 2019.
+
+msgid ""
+msgstr ""
+"Project-Id-Version: Coloured Chat\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-08-13 7:26+0200\n"
+"PO-Revision-Date: \n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: \n"
+"Language: es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: init.lua
+msgid "Allows players to colour their chat messages."
+msgstr "Permite a los jugadors colorear sus mensajes."
+
+#: init.lua
+msgid "Sends a public warning to all players."
+msgstr "Envía una advertencia pública a todos los jugadores."
+
+#: init.lua
+msgid "<text>"
+msgstr "<texto>"
+
+#: init.lua
+msgid "[MOD] Coloured-chat loaded"
+msgstr "[MOD] Chat-coloreado cargado"

--- a/locale/template.pot
+++ b/locale/template.pot
@@ -1,0 +1,33 @@
+# Template translation for Coloured Chat.
+# Copyright (C) 2017-2019 wilkgr76 and contributors.
+# This file is distributed under under the same license as the Teleport Request package.
+# Panquesito7, 2019.
+
+msgid ""
+msgstr ""
+"Project-Id-Version: Coloured Chat\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-08-13 7:26+0200\n"
+"PO-Revision-Date: \n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: \n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: init.lua
+msgid "Allows players to colour their chat messages."
+msgstr ""
+
+#: init.lua
+msgid "Sends a public warning to all players."
+msgstr ""
+
+#: init.lua
+msgid "<text>"
+msgstr ""
+
+#: init.lua
+msgid "[MOD] Coloured-chat loaded"
+msgstr ""

--- a/mod.conf
+++ b/mod.conf
@@ -1,1 +1,3 @@
 name = chat_c
+depends = default
+description = Allows players to colour their chat messages.

--- a/mod.conf
+++ b/mod.conf
@@ -1,3 +1,4 @@
 name = chat_c
 depends = default
+optional_depends = intllib
 description = Allows players to colour their chat messages.


### PR DESCRIPTION
Also adds support for [intllib](https://github.com/minetest-mods/intllib) and improves `README.md`.
Tested with MT/MTG 5.0.1 and works fine.

If there's any bug/error/typo (or something you don't like), please tell me, so, I can fix it.